### PR TITLE
fix: package core, streamline bootstrap, and test config loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ datasets/sessions/
 *.log
 .env
 .DS_Store
+# Local live config (seeded from cfg.sample)
+cfg/

--- a/cfg.sample/budgets.yaml
+++ b/cfg.sample/budgets.yaml
@@ -1,0 +1,6 @@
+global: { wall_clock_day_min: 60, cpu_time_day_sec: 18000, energy_kj_day: 1200, max_parallel_tasks: 2 }
+scopes:
+  hygiene:   { wall_clock: 10, cpu_time: 600,  retry_limit: 1 }
+  refactor:  { wall_clock: 30, cpu_time: 2400, retry_limit: 3 }
+  feature:   { wall_clock: 45, cpu_time: 3600, retry_limit: 3 }
+  migration: { wall_clock: 90, cpu_time: 7200, retry_limit: 4 }

--- a/cfg.sample/drives.yaml
+++ b/cfg.sample/drives.yaml
@@ -1,0 +1,7 @@
+drives:
+  progress:   { metric: git.prs_per_week,    target: 7,   weight: 0.35 }
+  integrity:  { metric: tests.pass_rate,     target: 0.98, weight: 0.30 }
+  efficiency: { metric: mean.mins_per_ticket,target: 45,  weight: 0.15, direction: decrease }
+  ergonomics: { metric: lint.warnings,       target: 0,   weight: 0.10, direction: decrease }
+  stability:  { metric: git.rollbacks_30d,   target: 0,   weight: 0.10, direction: decrease }
+activation: { min_tension: 0.08, satiety_hysteresis: 0.03 }

--- a/cfg.sample/policies.yaml
+++ b/cfg.sample/policies.yaml
@@ -1,0 +1,13 @@
+autonomy_ladder:
+  - { name: observe,     act: false, require_approvals: none,     min_competence: 0.0, max_risk: 1.0 }
+  - { name: propose,     act: false, require_approvals: none,     min_competence: 0.3, max_risk: 0.8 }
+  - { name: act_limited, act: true,  require_approvals: commands, min_competence: 0.5, max_risk: 0.6 }
+  - { name: act_full,    act: true,  require_approvals: none,     min_competence: 0.7, max_risk: 0.4 }
+risk_model:
+  weights: { surface_area: 0.35, reversibility: 0.25, blast_radius: 0.25, novelty: 0.15 }
+  cutoffs: { red: 0.7, amber: 0.4 }
+confidence: { min_brier_improvement: 0.02, decay_per_week: 0.01 }
+approvals:
+  safe_commands: ["pnpm test -w", "pnpm lint --fix", "ruff --fix", "pytest -q", "go test ./..."]
+  path_allowlist: ["./src", "./tests", "./docs", "./tools"]
+  deny_patterns: ["|", ">", "<(", "curl", "nc", "scp", "ssh", "/etc", "/var", "~"]

--- a/cfg.sample/self.yaml
+++ b/cfg.sample/self.yaml
@@ -1,0 +1,6 @@
+name: Eidos
+workspace: .
+axioms: ["Verify with tests", "Keep diffs small"]
+non_negotiables: ["workspace-only unless scope extends"]
+temperament: { novelty_bias: 0.25, risk_aversion: 0.6, patience: 0.7 }
+commit_style: "conventional"

--- a/cfg.sample/skills.yaml
+++ b/cfg.sample/skills.yaml
@@ -1,0 +1,5 @@
+competencies:
+  js_refactor:    { level: 0.50, brier: 0.25 }
+  python_tooling: { level: 0.50, brier: 0.25 }
+  e2e_playwright: { level: 0.40, brier: 0.30 }
+  sql_migrations: { level: 0.45, brier: 0.28 }

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# Explicit package marker for core. Keep empty on purpose.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = examples

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -9,12 +9,28 @@ say() { printf "[bootstrap] %s\n" "$*"; }
 
 need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "Missing: $1"; exit 1; }; }
 
+usage() { echo "Usage: scripts/bootstrap.sh [--full]"; }
+
+FULL=0
+for arg in "$@"; do
+  case "$arg" in
+    --full) FULL=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
 main() {
   need_cmd bash
   need_cmd python3
 
   say "Creating base directories"
-  mkdir -p "$root_dir"/{cfg,core,planners/templates,actuators,instruments,reflect,ui,psyche,memory,learners,meta,embodiment,protocols/keys,net,sensors/camera/calib_db,sensors/{imu,lidar,audio,power,env},actuators_hw/{base,manip,io},control,safety,teleop,sim,datasets/sessions,ops,curriculum/{syllabus,generators,grader,bank},arenas,oracles/{property_tests,contracts,fuzzers},curiosity,forge/{dsl,catalog},model_lab/{adapters,distillers,calibration},atlas/{maps,roadmaps,chronicle},introspection,charter/audits,social,economy,population/genealogy,backups/parity,creative/{stylebook,moodboard},telemetry/dashboards,provenance/repro,legal,rituals,grants/{proposals,audits},state/{events,vector_store,weights,adapters,snaps}}
+  mkdir -p "$root_dir"/{cfg,core,scripts,state/{events,vector_store,weights,adapters,snaps},tests}
+
+  if [ "$FULL" -eq 1 ]; then
+    say "Creating extended directories (--full)"
+    mkdir -p "$root_dir"/{planners/templates,actuators,instruments,reflect,ui,psyche,memory,learners,meta,embodiment,protocols/keys,net,sensors/camera/calib_db,sensors/{imu,lidar,audio,power,env},actuators_hw/{base,manip,io},control,safety,teleop,sim,datasets/sessions,ops,curriculum/{syllabus,generators,grader,bank},arenas,oracles/{property_tests,contracts,fuzzers},curiosity,forge/{dsl,catalog},model_lab/{adapters,distillers,calibration},atlas/{maps,roadmaps,chronicle},introspection,charter/audits,social,economy,population/genealogy,backups/parity,creative/{stylebook,moodboard},telemetry/dashboards,provenance/repro,legal,rituals,grants/{proposals,audits}}
+  fi
 
   say "Seeding minimal config files (only if absent)"
   seed_cfg
@@ -26,7 +42,7 @@ main() {
   # shellcheck disable=SC1091
   source "$root_dir/.venv/bin/activate"
   python -m pip install -U pip wheel >/dev/null
-  python -m pip install --quiet pyyaml
+  python -m pip install --quiet 'pyyaml>=6,<7'
 
   say "Touch state files"
   : >"$root_dir/state/events/.keep"
@@ -35,76 +51,21 @@ main() {
   : >"$root_dir/state/adapters/.keep"
   : >"$root_dir/state/snaps/.keep"
 
+  say "Summary: $(python -V 2>&1), PyYAML=$(python -c 'import yaml,sys;print(yaml.__version__)')"
   say "Done. Next: add core/state.py migrations and core/config.py loader."
 }
 
 seed_cfg() {
-  # cfg/self.yaml
-  if [ ! -f "$root_dir/cfg/self.yaml" ]; then
-cat >"$root_dir/cfg/self.yaml" <<'YAML'
-name: Eidos
-workspace: .
-axioms: ["Verify with tests", "Keep diffs small"]
-non_negotiables: ["workspace-only unless scope extends"]
-temperament: { novelty_bias: 0.25, risk_aversion: 0.6, patience: 0.7 }
-commit_style: "conventional"
-YAML
+  if [ ! -d "$root_dir/cfg.sample" ]; then
+    say "WARNING: cfg.sample missing; cannot seed cfg/"
+    return 0
   fi
-
-  # cfg/drives.yaml
-  if [ ! -f "$root_dir/cfg/drives.yaml" ]; then
-cat >"$root_dir/cfg/drives.yaml" <<'YAML'
-drives:
-  progress:   { metric: git.prs_per_week,    target: 7,   weight: 0.35 }
-  integrity:  { metric: tests.pass_rate,     target: 0.98, weight: 0.30 }
-  efficiency: { metric: mean.mins_per_ticket,target: 45,  weight: 0.15, direction: decrease }
-  ergonomics: { metric: lint.warnings,       target: 0,   weight: 0.10, direction: decrease }
-  stability:  { metric: git.rollbacks_30d,   target: 0,   weight: 0.10, direction: decrease }
-activation: { min_tension: 0.08, satiety_hysteresis: 0.03 }
-YAML
-  fi
-
-  # cfg/budgets.yaml
-  if [ ! -f "$root_dir/cfg/budgets.yaml" ]; then
-cat >"$root_dir/cfg/budgets.yaml" <<'YAML'
-global: { wall_clock_day_min: 60, cpu_time_day_sec: 18000, energy_kj_day: 1200, max_parallel_tasks: 2 }
-scopes:
-  hygiene:   { wall_clock: 10, cpu_time: 600,  retry_limit: 1 }
-  refactor:  { wall_clock: 30, cpu_time: 2400, retry_limit: 3 }
-  feature:   { wall_clock: 45, cpu_time: 3600, retry_limit: 3 }
-  migration: { wall_clock: 90, cpu_time: 7200, retry_limit: 4 }
-YAML
-  fi
-
-  # cfg/policies.yaml
-  if [ ! -f "$root_dir/cfg/policies.yaml" ]; then
-cat >"$root_dir/cfg/policies.yaml" <<'YAML'
-autonomy_ladder:
-  - { name: observe,     act: false, require_approvals: none,     min_competence: 0.0, max_risk: 1.0 }
-  - { name: propose,     act: false, require_approvals: none,     min_competence: 0.3, max_risk: 0.8 }
-  - { name: act_limited, act: true,  require_approvals: commands, min_competence: 0.5, max_risk: 0.6 }
-  - { name: act_full,    act: true,  require_approvals: none,     min_competence: 0.7, max_risk: 0.4 }
-risk_model:
-  weights: { surface_area: 0.35, reversibility: 0.25, blast_radius: 0.25, novelty: 0.15 }
-  cutoffs: { red: 0.7, amber: 0.4 }
-confidence: { min_brier_improvement: 0.02, decay_per_week: 0.01 }
-approvals:
-  safe_commands: ["pnpm test -w", "pnpm lint --fix", "ruff --fix", "pytest -q", "go test ./..."]
-  path_allowlist: ["./src", "./tests", "./docs", "./tools"]
-  deny_patterns: ["|", ">", "<(", "curl", "nc", "scp", "ssh", "/etc", "/var", "~"]
-YAML
-  fi
-
-  # cfg/skills.yaml
-  if [ ! -f "$root_dir/cfg/skills.yaml" ]; then
-cat >"$root_dir/cfg/skills.yaml" <<'YAML'
-competencies:
-  js_refactor:    { level: 0.50, brier: 0.25 }
-  python_tooling: { level: 0.50, brier: 0.25 }
-  e2e_playwright: { level: 0.40, brier: 0.30 }
-  sql_migrations: { level: 0.45, brier: 0.28 }
-YAML
-  fi
+  mkdir -p "$root_dir/cfg"
+  for f in self.yaml drives.yaml budgets.yaml policies.yaml skills.yaml; do
+    if [ ! -f "$root_dir/cfg/$f" ]; then
+      cp "$root_dir/cfg.sample/$f" "$root_dir/cfg/$f"
+    fi
+  done
 }
 
 main "$@"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# add repo root to sys.path so 'core' can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -1,0 +1,38 @@
+import os
+import json
+import shutil
+from pathlib import Path
+
+from core import config as C
+
+def make_tmp_cfg(tmp_path: Path):
+    # copy from sample to avoid writing fixtures manually
+    src = Path("cfg.sample")
+    dst = tmp_path / "cfg"
+    shutil.copytree(src, dst)
+    return dst
+
+def test_load_and_print(tmp_path, monkeypatch):
+    cfg_dir = make_tmp_cfg(tmp_path)
+    monkeypatch.setenv("EIDOS_WS", "/tmp/eidos")
+    # add an env var and check expansion by editing workspace on the fly
+    p = cfg_dir / "self.yaml"
+    text = p.read_text(encoding="utf-8").replace("workspace: .", "workspace: ${EIDOS_WS}")
+    p.write_text(text, encoding="utf-8")
+
+    cfg = C.load_all(cfg_dir)
+    assert cfg.self.name == "Eidos"
+    assert cfg.self.workspace == "/tmp/eidos"
+    d = C.to_dict(cfg)
+    j = json.dumps(d)  # must be serializable
+
+
+def test_validation_error_on_type(tmp_path):
+    cfg_dir = make_tmp_cfg(tmp_path)
+    p = cfg_dir / "drives.yaml"
+    p.write_text(p.read_text().replace("target: 7", 'target: "seven"'), encoding="utf-8")
+    try:
+        C.load_all(cfg_dir)
+        assert False, "should have failed"
+    except (TypeError, ValueError) as e:
+        assert "drives.yaml" in str(e)


### PR DESCRIPTION
## Summary
- mark `core` as explicit package and ensure config serialization stays JSON-friendly
- simplify bootstrap with minimal scaffold by default, optional `--full` expansion, and pinned PyYAML
- track sample configs, seed live `cfg/` from them, and ignore local config
- add unit tests exercising config loading, env expansion, and validation errors

## Testing
- `python -m core.config --dir cfg --print`
- `python -m core.config --dir cfg --validate`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899acd1fa308323b94d22fc00306902