### PR TITLE
feat(state): add minimal state layer with migrations, journal and CLI snapshot

### DIFF
--- a/bin/eidctl
+++ b/bin/eidctl
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+eidctl — tiny control CLI for Eidos E3
+
+Usage examples:
+  bin/eidctl state --migrate
+  bin/eidctl state --json
+  bin/eidctl journal --add "first run" --dir state
+"""
+
+from __future__ import annotations
+import argparse, json, sys
+from pathlib import Path
+
+# local import; stdlib only
+from core.state import migrate, snapshot, append_journal  # type: ignore
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="eidctl", description="Eidos control CLI")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_state = sub.add_parser("state", help="print state snapshot")
+    p_state.add_argument("--dir", default="state", help="state directory (default: state)")
+    p_state.add_argument("--json", action="store_true", help="print JSON instead of pretty text")
+    p_state.add_argument("--migrate", action="store_true", help="ensure directories/version exist")
+
+    p_journal = sub.add_parser("journal", help="append to journal")
+    p_journal.add_argument("--dir", default="state", help="state directory (default: state)")
+    p_journal.add_argument("--add", metavar="TEXT", help="text to append as a journal note")
+    p_journal.add_argument("--type", default="note", help="event type, e.g. goal.created")
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "state":
+        if args.migrate:
+            migrate(args.dir)
+        snap = snapshot(args.dir)
+        if args.json:
+            print(json.dumps(snap, indent=2))
+        else:
+            _pretty_print_state(snap)
+        return 0
+
+    if args.cmd == "journal":
+        if not args.add:
+            p_journal.error("journal requires --add TEXT")
+        evt = append_journal(args.dir, args.add, etype=args.type)
+        print(f"[journal] appended: {evt['type']} @ {evt['ts']}")
+        return 0
+
+    return 2
+
+def _pretty_print_state(snap: dict) -> None:
+    print(f"[state] base: {snap.get('base')}")
+    print(f"  schema: {snap.get('schema')}")
+    t = snap.get("totals", {})
+    print("  totals: " + ", ".join(f"{k}={t[k]}" for k in sorted(t.keys())))
+    last = snap.get("last_events", [])
+    if last:
+        print("  last:")
+        for e in last:
+            print(f"    - {e.get('ts')}  {e.get('type')}: {e.get('text')}")
+    files = snap.get("files", {})
+    print("  files:  " + ", ".join(f"{k}={files.get(k,0)}" for k in ["events","vector_store","weights","adapters","snaps"]))
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())
+

--- a/core/state.py
+++ b/core/state.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Minimal state layer for Eidos E3.
+
+- state/ layout assumed by bootstrap:
+    state/
+      events/
+      vector_store/
+      weights/
+      adapters/
+      snaps/
+      meta/ (created on demand)
+
+- JSONL journal at: state/events/journal.jsonl
+- Schema/version marker: state/meta/version.json
+
+Public API (stdlib only):
+    migrate(base="state") -> int
+    append_journal(base, text, *, etype="note", tags=None, extra=None) -> dict
+    snapshot(base="state") -> dict
+"""
+
+from __future__ import annotations
+import dataclasses as dc
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Tuple
+
+SCHEMA_VERSION = 1
+
+# ---------- internal paths ----------
+
+def _p(base: Path) -> Dict[str, Path]:
+    return {
+        "base": base,
+        "events": base / "events",
+        "meta": base / "meta",
+        "journal": base / "events" / "journal.jsonl",
+        "version": base / "meta" / "version.json",
+    }
+
+def _ensure_dirs(base: Path) -> None:
+    p = _p(base)
+    p["events"].mkdir(parents=True, exist_ok=True)
+    p["meta"].mkdir(parents=True, exist_ok=True)
+
+# ---------- migrations ----------
+
+def migrate(base: str | Path = "state") -> int:
+    """Ensure directory structure and bump/create version marker if absent."""
+    b = Path(base)
+    _ensure_dirs(b)
+    paths = _p(b)
+    vp = paths["version"]
+    jp = paths["journal"]
+    if not jp.exists():
+        jp.touch()
+    if not vp.exists():
+        vp.write_text(json.dumps({"schema": SCHEMA_VERSION, "created_at": _now_iso()}), encoding="utf-8")
+        return SCHEMA_VERSION
+    try:
+        meta = json.loads(vp.read_text(encoding="utf-8"))
+        return int(meta.get("schema", SCHEMA_VERSION))
+    except Exception:
+        # if corrupted, do not overwrite silently; surface but return current
+        raise RuntimeError(f"Corrupted version file: {vp}")
+
+# ---------- journal ----------
+
+def append_journal(
+    base: str | Path,
+    text: str,
+    *,
+    etype: str = "note",
+    tags: List[str] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Append a single journal event as JSONL and return the event dict."""
+    b = Path(base)
+    _ensure_dirs(b)
+    evt = {
+        "ts": _now_iso(),
+        "type": str(etype),
+        "text": str(text),
+        "tags": list(tags or []),
+        "extra": dict(extra or {}),
+    }
+    jp = _p(b)["journal"]
+    with jp.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(evt, ensure_ascii=False) + "\n")
+    return evt
+
+# ---------- snapshot ----------
+
+def snapshot(base: str | Path = "state") -> Dict[str, Any]:
+    """Compute a light snapshot: counts by entity family, last 5 journal entries, file counts."""
+    b = Path(base)
+    _ensure_dirs(b)
+    version = migrate(b)  # idempotent
+
+    # parse journal (if any)
+    journal_path = _p(b)["journal"]
+    last: List[Dict[str, Any]] = []
+    counts: Dict[str, int] = {"goal": 0, "plan": 0, "step": 0, "run": 0, "metric": 0, "journal": 0, "note": 0}
+    if journal_path.exists():
+        # one pass to count & also keep last 5
+        buf: List[Dict[str, Any]] = []
+        with journal_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    evt = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                etype = str(evt.get("type", "note"))
+                family = etype.split(".", 1)[0] if etype else "note"
+                counts[family] = counts.get(family, 0) + 1
+                buf.append(evt)
+        last = buf[-5:]
+
+    # files (quick health signal)
+    files = {
+        "events": _file_count(_p(b)["events"]),
+        "vector_store": _file_count(b / "vector_store"),
+        "weights": _file_count(b / "weights"),
+        "adapters": _file_count(b / "adapters"),
+        "snaps": _file_count(b / "snaps"),
+    }
+
+    return {
+        "schema": version,
+        "base": str(b.resolve()),
+        "totals": counts,
+        "last_events": last,
+        "files": files,
+        "generated_at": _now_iso(),
+    }
+
+# ---------- helpers ----------
+
+def _file_count(d: Path) -> int:
+    if not d.exists():
+        return 0
+    return sum(1 for _ in d.rglob("*") if _.is_file())
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+if __name__ == "__main__":  # pragma: no cover
+    # tiny manual smoke test
+    migrate("state")
+    append_journal("state", "hello world", etype="note", tags=["smoke"])
+    print(json.dumps(snapshot("state"), indent=2))
+

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from core import state as S
+
+def test_migrate_and_snapshot(tmp_path: Path):
+    base = tmp_path / "state"
+    v = S.migrate(base)
+    assert v >= 1
+    snap = S.snapshot(base)
+    assert snap["schema"] == v
+    assert snap["totals"]["note"] == 0
+    assert snap["files"]["events"] >= 1  # at least version/journal files
+
+def test_journal_counts(tmp_path: Path):
+    base = tmp_path / "state"
+    S.migrate(base)
+    S.append_journal(base, "g1", etype="goal.created")
+    S.append_journal(base, "p1", etype="plan.created")
+    S.append_journal(base, "s1", etype="step.completed")
+    S.append_journal(base, "metric logged", etype="metric.logged")
+    S.append_journal(base, "note only")  # default type note
+
+    snap = S.snapshot(base)
+    assert snap["totals"]["goal"] == 1
+    assert snap["totals"]["plan"] == 1
+    assert snap["totals"]["step"] == 1
+    assert snap["totals"]["metric"] == 1
+    assert snap["totals"]["note"] >= 1  # includes our note
+    assert len(snap["last_events"]) <= 5
+


### PR DESCRIPTION
## Summary
- implement strict `core/state.py` with migrations, journaling and snapshot counts
- add `eidctl` CLI to migrate, inspect state and append journal events
- cover state layer with tests for migrations and journal counting

## Testing
- `PYTHONPATH=. bin/eidctl state --migrate`
- `PYTHONPATH=. bin/eidctl state`
- `PYTHONPATH=. bin/eidctl state --json | head -n 20`
- `PYTHONPATH=. bin/eidctl journal --add "first entry"`
- `PYTHONPATH=. bin/eidctl state`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899b7607ea48323b9e431914a6f8022