### PR TITLE
feat(state): add snapshot persistence and CLI polish

### DIFF
--- a/bin/eidctl
+++ b/bin/eidctl
@@ -9,46 +9,72 @@ Usage examples:
 """
 
 from __future__ import annotations
-import argparse, json, sys
-from pathlib import Path
+import argparse, json
+
+# add repo root to sys.path so local 'core' can be imported without PYTHONPATH
+import sys
+from pathlib import Path as _P
+sys.path.insert(0, str(_P(__file__).resolve().parents[1]))
 
 # local import; stdlib only
-from core.state import migrate, snapshot, append_journal  # type: ignore
+from core.state import migrate, snapshot, append_journal, save_snapshot  # type: ignore
+
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(prog="eidctl", description="Eidos control CLI")
-    sub = ap.add_subparsers(dest="cmd", required=True)
+    try:
+        ap = argparse.ArgumentParser(
+            prog="eidctl",
+            description="Eidos control CLI",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        sub = ap.add_subparsers(dest="cmd", required=True)
 
-    p_state = sub.add_parser("state", help="print state snapshot")
-    p_state.add_argument("--dir", default="state", help="state directory (default: state)")
-    p_state.add_argument("--json", action="store_true", help="print JSON instead of pretty text")
-    p_state.add_argument("--migrate", action="store_true", help="ensure directories/version exist")
+        p_state = sub.add_parser("state", help="print state snapshot")
+        p_state.add_argument("--dir", default="state", help="state directory")
+        p_state.add_argument("--json", action="store_true", help="print JSON instead of pretty text")
+        p_state.add_argument("--migrate", action="store_true", help="ensure directories/version exist")
+        p_state.add_argument("--last", type=int, default=5, help="number of recent events to display")
+        p_state.add_argument("--save", action="store_true", help="save snapshot to state/snaps")
 
-    p_journal = sub.add_parser("journal", help="append to journal")
-    p_journal.add_argument("--dir", default="state", help="state directory (default: state)")
-    p_journal.add_argument("--add", metavar="TEXT", help="text to append as a journal note")
-    p_journal.add_argument("--type", default="note", help="event type, e.g. goal.created")
+        p_journal = sub.add_parser("journal", help="append to journal")
+        p_journal.add_argument("--dir", default="state", help="state directory")
+        p_journal.add_argument("--add", metavar="TEXT", help="text to append as a journal note")
+        p_journal.add_argument("--type", default="note", help="event type, e.g. goal.created")
+        p_journal.add_argument("--tags", help="comma-separated tags", default="")
 
-    args = ap.parse_args(argv)
+        args = ap.parse_args(argv)
 
-    if args.cmd == "state":
-        if args.migrate:
-            migrate(args.dir)
-        snap = snapshot(args.dir)
-        if args.json:
-            print(json.dumps(snap, indent=2))
-        else:
-            _pretty_print_state(snap)
-        return 0
+        if args.cmd == "state":
+            if args.migrate:
+                migrate(args.dir)
+            snap = snapshot(args.dir, last=args.last)
+            if args.save:
+                path = save_snapshot(args.dir, snap)
+                print(f"[state] saved snapshot -> {path}")
+            if args.json:
+                print(json.dumps(snap, indent=2))
+            else:
+                _pretty_print_state(snap)
+            return 0
 
-    if args.cmd == "journal":
-        if not args.add:
-            p_journal.error("journal requires --add TEXT")
-        evt = append_journal(args.dir, args.add, etype=args.type)
-        print(f"[journal] appended: {evt['type']} @ {evt['ts']}")
-        return 0
+        if args.cmd == "journal":
+            if not args.add:
+                if not sys.stdin.isatty():
+                    args.add = sys.stdin.read().strip()
+            if not args.add:
+                p_journal.error("journal requires --add TEXT (or pipe text to STDIN)")
+            tags = [t for t in (args.tags.split(",") if args.tags else []) if t]
+            evt = append_journal(args.dir, args.add, etype=args.type, tags=tags)
+            print(f"[journal] appended: {evt['type']} @ {evt['ts']}")
+            return 0
 
-    return 2
+        return 2
+    except KeyboardInterrupt:
+        print("aborted.", file=sys.stderr)
+        return 130
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
 
 def _pretty_print_state(snap: dict) -> None:
     print(f"[state] base: {snap.get('base')}")
@@ -59,7 +85,8 @@ def _pretty_print_state(snap: dict) -> None:
     if last:
         print("  last:")
         for e in last:
-            print(f"    - {e.get('ts')}  {e.get('type')}: {e.get('text')}")
+            tags = f" [{', '.join(e.get('tags', []))}]" if e.get('tags') else ""
+            print(f"    - {e.get('ts')}  {e.get('type')}: {e.get('text')}{tags}")
     files = snap.get("files", {})
     print("  files:  " + ", ".join(f"{k}={files.get(k,0)}" for k in ["events","vector_store","weights","adapters","snaps"]))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "eidos-e3"
+version = "0.0.1"
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 from core import state as S
 
 def test_migrate_and_snapshot(tmp_path: Path):
@@ -26,4 +27,49 @@ def test_journal_counts(tmp_path: Path):
     assert snap["totals"]["metric"] == 1
     assert snap["totals"]["note"] >= 1  # includes our note
     assert len(snap["last_events"]) <= 5
+
+
+def test_snapshot_save(tmp_path: Path):
+    base = tmp_path / "state"
+    S.migrate(base)
+    path = S.save_snapshot(base)
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["schema"] >= 1
+    assert "totals" in data
+
+
+def test_journal_tags(tmp_path: Path):
+    base = tmp_path / "state"
+    S.migrate(base)
+    S.append_journal(base, "hello", etype="note", tags=["x", "y"])
+    snap = S.snapshot(base)
+    assert snap["last_events"][-1]["tags"] == ["x", "y"]
+
+
+def test_migrate_idempotent(tmp_path: Path):
+    base = tmp_path / "state"
+    v1 = S.migrate(base)
+    v2 = S.migrate(base)
+    assert v1 == v2
+
+
+def test_snapshot_ignores_bad_journal_lines(tmp_path: Path):
+    base = tmp_path / "state"
+    S.migrate(base)
+    jp = (base / "events" / "journal.jsonl")
+    jp.write_text('{"type":"note","text":"ok"}\nTHIS IS NOT JSON\n', encoding="utf-8")
+    snap = S.snapshot(base)
+    assert snap["totals"]["note"] == 1
+
+
+def test_snapshot_last_param(tmp_path: Path):
+    base = tmp_path / "state"
+    S.migrate(base)
+    for i in range(7):
+        S.append_journal(base, f"n{i}")
+    snap = S.snapshot(base, last=3)
+    assert len(snap["last_events"]) == 3
+    snap2 = S.snapshot(base, last=0)
+    assert snap2["last_events"] == []
 


### PR DESCRIPTION
## Summary
- expose CLI defaults, safer error handling, and options to save snapshots or limit recent events
- persist snapshots atomically with Zulu timestamps and parameterized last-N events
- accept tagged journal entries and stdin input; ship minimal `pyproject.toml`

## Testing
- `scripts/bootstrap.sh`
- `bin/eidctl state --migrate`
- `bin/eidctl journal --add "first entry" --tags demo`
- `bin/eidctl state --save`
- `python -m pip install --quiet 'pytest>=8,<9'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899bf9279988323ae0649fbeb0905da