### PR TITLE
feat(state): rotate journal and diff snapshots

### DIFF
--- a/bin/eidctl
+++ b/bin/eidctl
@@ -17,7 +17,16 @@ from pathlib import Path as _P
 sys.path.insert(0, str(_P(__file__).resolve().parents[1]))
 
 # local import; stdlib only
-from core.state import migrate, snapshot, append_journal, save_snapshot, iter_journal  # type: ignore
+from core.state import (  # type: ignore
+    migrate,
+    snapshot,
+    append_journal,
+    save_snapshot,
+    iter_journal,
+    rotate_journal,
+    load_snapshot,
+    diff_snapshots,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -36,12 +45,19 @@ def main(argv: list[str] | None = None) -> int:
         p_state.add_argument("--last", type=int, default=5, help="number of recent events to display")
         p_state.add_argument("--save", action="store_true", help="save snapshot to state/snaps")
         p_state.add_argument("--name", help="optional label for --save filename")
+        p_state.add_argument(
+            "--diff",
+            nargs=2,
+            metavar=("A", "B"),
+            help="diff two snapshot files (paths). Use with --json for machine output.",
+        )
 
         p_journal = sub.add_parser("journal", help="append or inspect journal")
         p_journal.add_argument("--dir", default="state", help="state directory")
         mode = p_journal.add_mutually_exclusive_group()
         mode.add_argument("--add", metavar="TEXT", help="append a journal note (or pipe via STDIN)")
         mode.add_argument("--list", action="store_true", help="list entries")
+        mode.add_argument("--rotate", action="store_true", help="rotate journal file")
         p_journal.add_argument("--type", dest="etype", help="event type or filter by exact type")
         p_journal.add_argument("--tags", help="comma-separated tags", default="")
         p_journal.add_argument("--tag", help="filter by tag")
@@ -49,10 +65,27 @@ def main(argv: list[str] | None = None) -> int:
         p_journal.add_argument("--until", help="ISO8601 Z upper bound (inclusive)")
         p_journal.add_argument("--limit", type=int, default=10, help="max entries to return")
         p_journal.add_argument("--json", action="store_true", help="JSON output")
+        p_journal.add_argument(
+            "--max-bytes",
+            type=int,
+            default=5 * 1024 * 1024,
+            help="rotate threshold in bytes (with --rotate)",
+        )
+        p_journal.add_argument(
+            "--force", action="store_true", help="rotate even if under threshold"
+        )
 
         args = ap.parse_args(argv)
 
         if args.cmd == "state":
+            if args.diff:
+                a, b = args.diff
+                da = load_snapshot(a)
+                db = load_snapshot(b)
+                d = diff_snapshots(da, db)
+                out = json.dumps(d, indent=2) if args.json else d
+                print(out if isinstance(out, str) else json.dumps(out, indent=2))
+                return 0
             if args.migrate:
                 migrate(args.dir)
             snap = snapshot(args.dir, last=args.last)
@@ -66,6 +99,15 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         if args.cmd == "journal":
+            if args.rotate:
+                rot = rotate_journal(
+                    args.dir, max_bytes=args.max_bytes, force=args.force
+                )
+                if rot:
+                    print(f"[journal] rotated -> {rot}")
+                else:
+                    print("[journal] no rotation needed")
+                return 0
             if args.list:
                 items = iter_journal(
                     args.dir,

--- a/core/state.py
+++ b/core/state.py
@@ -30,7 +30,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Tuple
 
-__all__ = ["migrate", "append_journal", "snapshot", "save_snapshot", "iter_journal"]
+__all__ = [
+    "migrate",
+    "append_journal",
+    "snapshot",
+    "save_snapshot",
+    "iter_journal",
+    "rotate_journal",
+    "load_snapshot",
+    "diff_snapshots",
+]
 
 SCHEMA_VERSION = 1
 
@@ -135,6 +144,48 @@ def iter_journal(
     if limit is not None and limit >= 0:
         out = out[-limit:]
     return out
+
+
+def rotate_journal(
+    base: str | Path,
+    *,
+    max_bytes: int = 5 * 1024 * 1024,
+    force: bool = False,
+) -> Path | None:
+    """Rotate events/journal.jsonl if size exceeds ``max_bytes`` (or always if ``force``)."""
+    b = Path(base)
+    _ensure_dirs(b)
+    p = _p(b)
+    jp = p["journal"]
+    if not jp.exists():
+        return None
+    size = jp.stat().st_size
+    if not force and size <= max_bytes:
+        return None
+    ts = _now_iso().replace(":", "").replace("+00:00", "Z").replace("+", "Z")
+    rot = p["events"] / f"journal-{ts}.jsonl"
+    jp.rename(rot)
+    jp.touch()
+    return rot
+
+
+def load_snapshot(path: str | Path) -> Dict[str, Any]:
+    """Read a snapshot JSON file into a dict."""
+    p = Path(path)
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def diff_snapshots(a: Mapping[str, Any], b: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a minimal diff focusing on totals; positive numbers mean increases."""
+    at = dict(a.get("totals", {}))
+    bt = dict(b.get("totals", {}))
+    keys = set(at) | set(bt)
+    delta = {k: int(bt.get(k, 0)) - int(at.get(k, 0)) for k in sorted(keys)}
+    return {
+        "delta_totals": delta,
+        "from": {"generated_at": a.get("generated_at"), "schema": a.get("schema")},
+        "to": {"generated_at": b.get("generated_at"), "schema": b.get("schema")},
+    }
 
 # ---------- snapshot ----------
 


### PR DESCRIPTION
## Summary
- add journal rotation with size threshold and CLI support
- compute delta between snapshots and expose via `eidctl state --diff`

## Testing
- `scripts/bootstrap.sh`
- `pytest -q`
- `bin/eidctl journal --rotate --force`
- `bin/eidctl state --save --name before`
- `bin/eidctl journal --add "one"`
- `bin/eidctl state --save --name after`
- `bin/eidctl state --diff state/snaps/2025-08-11T115440Z-before.json state/snaps/2025-08-11T115443Z-after.json --json`


------
https://chatgpt.com/codex/tasks/task_b_6899d9281c048323adeb74dd13d0df84