### PR TITLE
feat: add retention and richer TUI

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -10,3 +10,8 @@
 - **beat**: one scheduler iteration producing metrics and events.
 - **tick**: configured interval between beats.
 - **eidtop**: curses TUI showing recent beats and metrics.
+- **retention**: pruning strategy keeping metrics, events, and journal size bounded.
+- **maintenance cycle**: periodic run deleting old metrics and events and rotating journal.
+- **prune_metrics**: DB helper removing older metric rows beyond a per-key limit.
+- **prune_old_days**: event bus helper deleting day directories older than ``keep_days``.
+- **prune_journal**: wrapper rotating journal file when size exceeds threshold.

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,8 @@ loop:
 	bin/eidosd --state-dir state --loop --tick 1 --max-beats 5
 	# quick health:
 	sqlite3 state/e3.sqlite "select key,count(*) from metrics group by key order by key;"
+
+.PHONY: loop-prune
+loop-prune:
+	bin/eidosd --state-dir state --loop --tick 0.5 --max-beats 300
+	sqlite3 state/e3.sqlite "select key,count(*) from metrics group by key order by key;"

--- a/README.md
+++ b/README.md
@@ -43,4 +43,20 @@ bin/eidosd --state-dir state --loop --tick 5
 ```
 bin/eidtop --state-dir state
 ```
-Keys: `q` quit, `r` refresh.
+Keys: `q` quit, `r` refresh, `p` pause, `m` cycle metric, `?` help.
+
+## Retention
+
+Add to `cfg/self.yaml` to control automatic pruning:
+
+```
+daemon:
+  retention:
+    metrics_per_key_max: 10000
+    events_keep_days: 7
+    journal_max_bytes: 5242880
+    maintenance_every_beats: 100
+```
+
+The daemon runs maintenance every `maintenance_every_beats` beats, pruning
+SQLite metrics, rotating the journal, and removing old event directories.

--- a/bin/eidosd
+++ b/bin/eidosd
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 import argparse
+import os
+import random
 import sys
 from pathlib import Path as _P
 try:
@@ -36,6 +38,9 @@ def run_once(state_dir: str, *, tick_secs: float, cpu: OM.CpuPercent) -> None:
         "system.mem_total_kb": s.get("mem_total_kb"),
         "system.mem_free_kb": s.get("mem_free_kb"),
         "system.mem_available_kb": s.get("mem_available_kb"),
+        "system.cpu_pct_total": s.get("cpu_pct_total"),
+        "system.swap_free_kb": s.get("swap_free_kb"),
+        "process.num_threads": p.get("num_threads"),
     }
     for name, val in metrics.items():
         if val is not None:
@@ -72,13 +77,19 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--tick", type=float, help="seconds between beats")
     ap.add_argument("--max-beats", type=int, default=0, help="stop after N beats (0=inf)")
     ap.add_argument("--jitter-ms", type=int, help="jitter per beat in ms")
+    ap.add_argument("--max-backoff-secs", type=float, help="maximum backoff in seconds")
     args = ap.parse_args(argv)
 
     cfg = _load_cfg()
     tick_secs = float(args.tick if args.tick is not None else cfg.get("tick_secs", 5))
     jitter_ms = int(args.jitter_ms if args.jitter_ms is not None else cfg.get("jitter_ms", 0))
-    max_backoff = float(cfg.get("max_backoff_secs", 30.0))
+    max_backoff = float(args.max_backoff_secs if args.max_backoff_secs is not None else cfg.get("max_backoff_secs", 30.0))
     max_beats = int(args.max_beats or cfg.get("max_beats", 0))
+    ret = cfg.get("retention", {})
+    metrics_max = int(ret.get("metrics_per_key_max", 10000))
+    events_days = int(ret.get("events_keep_days", 7))
+    journal_max = int(ret.get("journal_max_bytes", 5 * 1024 * 1024))
+    maint_every = int(ret.get("maintenance_every_beats", 100))
 
     try:
         S.migrate(args.state_dir)
@@ -90,7 +101,10 @@ def main(argv: list[str] | None = None) -> int:
     cpu = OM.CpuPercent()
     if args.once:
         try:
-            run_once(args.state_dir, tick_secs=tick_secs, cpu=cpu)
+            DB.insert_metric(args.state_dir, "daemon.heartbeat", random.random())
+            DB.insert_journal(args.state_dir, "daemon", "once")
+            E.append(args.state_dir, "daemon.once", {"pid": os.getpid()})
+            S.append_journal(args.state_dir, "daemon once", etype="daemon.once")
             return 0
         except Exception as e:
             print(f"eidosd run error: {e}", file=sys.stderr)
@@ -104,8 +118,25 @@ def main(argv: list[str] | None = None) -> int:
             max_backoff_secs=max_backoff,
             max_beats=max_beats,
         )
+        beats = 0
+
+        def _beat() -> None:
+            nonlocal beats
+            run_once(args.state_dir, tick_secs=tick_secs, cpu=cpu)
+            beats += 1
+            if beats % maint_every == 0:
+                try:
+                    DB.prune_metrics(args.state_dir, per_key_max=metrics_max)
+                    E.prune_old_days(args.state_dir, keep_days=events_days)
+                    S.prune_journal(args.state_dir, max_bytes=journal_max)
+                    DB.insert_journal(args.state_dir, "daemon.maintenance", "maintenance")
+                    S.append_journal(args.state_dir, "daemon maintenance", etype="daemon.maintenance")
+                except Exception as e:
+                    S.append_journal(args.state_dir, f"maintenance error: {e}", etype="daemon.maintenance")
+                beats = 0
+
         try:
-            SCH.run_loop(cfg_obj, lambda: run_once(args.state_dir, tick_secs=tick_secs, cpu=cpu), stop=token)
+            SCH.run_loop(cfg_obj, _beat, stop=token)
             return 0
         except Exception as e:
             print(f"eidosd loop error: {e}", file=sys.stderr)

--- a/bin/eidtop
+++ b/bin/eidtop
@@ -18,12 +18,15 @@ METRIC_NAMES = [
     "process.cpu_user_s",
     "process.cpu_sys_s",
     "process.cpu_pct",
+    "process.num_threads",
     "system.load1",
     "system.load5",
     "system.load15",
     "system.mem_total_kb",
     "system.mem_free_kb",
     "system.mem_available_kb",
+    "system.cpu_pct_total",
+    "system.swap_free_kb",
 ]
 
 
@@ -55,7 +58,17 @@ def _human_bytes(n: float | int | None) -> str:
     return f"{n:.1f}TB"
 
 
-def render(model: Dict[str, object]) -> List[str]:
+def render(model: Dict[str, object], *, width: int = 80) -> List[str]:
+    """Render model into lines; pure for testing."""
+    if model.get("show_help"):
+        return [
+            "keys:",
+            " q quit",
+            " r refresh",
+            " p pause",
+            " m cycle metric",
+            " ? help",
+        ]
     lines: List[str] = []
     events: List[Dict[str, object]] = model.get("events", [])  # type: ignore
     last = events[-1] if events else {}
@@ -65,14 +78,36 @@ def render(model: Dict[str, object]) -> List[str]:
     rss = _human_bytes(data.get("rss_bytes"))
     load1 = data.get("load1")
     tick = data.get("tick_secs")
-    lines.append(f"last {ts} | cpu {cpu} | rss {rss} | load1 {load1} | tick {tick}")
+    status = f"last {ts} | cpu {cpu} | rss {rss} | load1 {load1} | tick {tick}"
+    if model.get("paused"):
+        status += " [PAUSED]"
+    lines.append(status[:width])
+
+    left: List[str] = []
+    for e in events[-20:]:
+        d = e.get("data", {})
+        ts = str(e.get("ts", ""))[-8:]
+        left.append(
+            f"{ts} cpu {d.get('cpu_pct')} rss {_human_bytes(d.get('rss_bytes'))}"
+        )
+
+    focus = model.get("focus", METRIC_NAMES[0])
     metrics: Dict[str, List[Tuple[str, float]]] = model.get("metrics", {})  # type: ignore
-    for name in METRIC_NAMES:
-        vals = [v for _, v in metrics.get(name, [])][-10:]
-        if vals:
-            spark = "".join(_spark(vals))
-            lines.append(f"{name:25s} {vals[-1]:>8.2f} {spark}")
-    lines.append("[q] quit  [r] refresh")
+    vals = [v for _, v in metrics.get(focus, [])]
+    right: List[str] = []
+    if vals:
+        spark = "".join(_spark(vals))
+        mn, mx = min(vals), max(vals)
+        avg = sum(vals) / len(vals)
+        right = [focus, spark, f"min {mn:.2f} avg {avg:.2f} max {mx:.2f}"]
+
+    column = width // 2
+    for i in range(max(len(left), len(right))):
+        l = left[i] if i < len(left) else ""
+        r = right[i] if i < len(right) else ""
+        lines.append(f"{l[:column-1]:<{column}}{r[:width-column]}")
+
+    lines.append("[q] quit [r] refresh [p] pause [m] metric [?] help")
     return lines
 
 
@@ -98,9 +133,17 @@ def main(argv: List[str] | None = None) -> int:
 
     def _loop(stdscr):
         curses.curs_set(0)
+        paused = False
+        focus_idx = 0
+        show_help = False
+        model: Dict[str, object] = {}
         while True:
-            model = gather_model(args.state_dir)
-            lines = render(model)
+            if not paused or not model:
+                model = gather_model(args.state_dir)
+            model["paused"] = paused
+            model["focus"] = METRIC_NAMES[focus_idx]
+            model["show_help"] = show_help
+            lines = render(model, width=curses.COLS)
             stdscr.erase()
             for i, line in enumerate(lines):
                 try:
@@ -108,12 +151,19 @@ def main(argv: List[str] | None = None) -> int:
                 except curses.error:
                     pass
             stdscr.refresh()
-            stdscr.timeout(1000)
+            stdscr.timeout(1000 if not paused else -1)
             ch = stdscr.getch()
             if ch in (ord("q"), ord("Q")):
                 break
             if ch in (ord("r"), ord("R")):
                 continue
+            if ch in (ord("p"), ord("P")):
+                paused = not paused
+            elif ch in (ord("m"), ord("M")):
+                focus_idx = (focus_idx + 1) % len(METRIC_NAMES)
+            elif ch in (ord("?"),):
+                show_help = not show_help
+
     curses.wrapper(_loop)
     return 0
 

--- a/core/state.py
+++ b/core/state.py
@@ -37,6 +37,7 @@ __all__ = [
     "save_snapshot",
     "iter_journal",
     "rotate_journal",
+    "prune_journal",
     "load_snapshot",
     "diff_snapshots",
 ]
@@ -166,6 +167,11 @@ def rotate_journal(
     jp.rename(rot)
     jp.touch()
     return rot
+
+
+def prune_journal(base: str | Path, *, max_bytes: int = 5 * 1024 * 1024) -> Path | None:
+    """Rotate journal if it exceeds ``max_bytes``; return rotated path or ``None``."""
+    return rotate_journal(base, max_bytes=max_bytes)
 
 
 def load_snapshot(path: str | Path) -> Dict[str, Any]:

--- a/tests/test_db_and_daemon.py
+++ b/tests/test_db_and_daemon.py
@@ -25,12 +25,12 @@ def test_eidosd_once(tmp_path: Path):
     assert res.returncode == 0, res.stderr
 
     conn = sqlite3.connect(state_dir / "e3.sqlite")
-    assert conn.execute("SELECT count(*) FROM metrics").fetchone()[0] >= 1
+    assert conn.execute("SELECT count(*) FROM metrics").fetchone()[0] == 1
     assert conn.execute("SELECT count(*) FROM journal").fetchone()[0] == 1
     conn.close()
 
-    assert E.files_count(state_dir) >= 1
-    assert len(E.iter_events(state_dir, limit=None)) >= 1
+    assert E.files_count(state_dir) == 1
+    assert len(E.iter_events(state_dir, limit=None)) == 1
 
     journal = S.iter_journal(state_dir, limit=None)
     assert len(journal) == 1

--- a/tests/test_db_retention.py
+++ b/tests/test_db_retention.py
@@ -1,0 +1,18 @@
+import sqlite3
+
+from core import db as DB
+
+
+def test_prune_metrics(tmp_path):
+    base = tmp_path / "state"
+    for i in range(6000):
+        ts = f"{i:05d}"
+        DB.insert_metric(base, "a", 1.0, ts=ts)
+        DB.insert_metric(base, "b", 2.0, ts=ts)
+    deleted = DB.prune_metrics(base, per_key_max=1000)
+    assert deleted == 10000
+    conn = sqlite3.connect(base / "e3.sqlite")
+    counts = dict(conn.execute("SELECT key, count(*) FROM metrics GROUP BY key"))
+    conn.close()
+    assert counts == {"a": 1000, "b": 1000}
+

--- a/tests/test_eidtop_controls.py
+++ b/tests/test_eidtop_controls.py
@@ -1,0 +1,29 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load():
+    loader = importlib.machinery.SourceFileLoader("eidtop", str(Path("bin/eidtop")))
+    spec = importlib.util.spec_from_loader("eidtop", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+def test_render_pause_and_stats():
+    mod = _load()
+    model = {
+        "events": [
+            {
+                "ts": "2024-01-01T00:00:00Z",
+                "data": {"cpu_pct": 1.0, "rss_bytes": 1000},
+            }
+        ],
+        "metrics": {"process.cpu_pct": [("t1", 1.0), ("t2", 2.0)]},
+        "paused": True,
+        "focus": "process.cpu_pct",
+    }
+    lines = mod.render(model, width=200)
+    assert any("PAUSED" in line for line in lines)
+    assert any("min" in line and "avg" in line and "max" in line for line in lines)
+

--- a/tests/test_events_prune.py
+++ b/tests/test_events_prune.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from core import events as E
+
+
+def test_prune_old_days(tmp_path):
+    base = tmp_path / "state"
+    events_dir = base / "events"
+    events_dir.mkdir(parents=True)
+    now = datetime.now(timezone.utc)
+    for i in range(5):
+        day = (now - timedelta(days=i + 1)).strftime("%Y%m%d")
+        (events_dir / day).mkdir()
+    deleted = E.prune_old_days(base, keep_days=3)
+    assert deleted == 2
+    remaining = sorted(p.name for p in events_dir.iterdir())
+    assert len(remaining) == 3
+

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -1,0 +1,14 @@
+import sqlite3
+
+from core import db as DB
+
+
+def test_metrics_index(tmp_path):
+    base = tmp_path / "state"
+    DB.init_db(base)
+    conn = sqlite3.connect(base / "e3.sqlite")
+    idxs = conn.execute("PRAGMA index_list(metrics)").fetchall()
+    conn.close()
+    names = [row[1] for row in idxs]
+    assert "idx_metrics_key_ts" in names
+

--- a/tests/test_os_metrics.py
+++ b/tests/test_os_metrics.py
@@ -5,7 +5,7 @@ from core import os_metrics as OM
 
 def test_process_stats_keys():
     stats = OM.process_stats()
-    assert set(stats) == {"rss_bytes", "cpu_user_s", "cpu_sys_s"}
+    assert {"rss_bytes", "cpu_user_s", "cpu_sys_s"}.issubset(stats)
     for v in stats.values():
         assert v is None or v >= 0
 


### PR DESCRIPTION
## Summary
- restore legacy single-metric beat for `--once`
- add configurable retention with SQLite indexes and maintenance pruning
- enrich `eidtop` with pause/help/metric panes and optional psutil metrics

## Testing
- `make smoke`
- `.venv/bin/python -m pytest -q`
- `make loop-prune`
- manual TUI render of help, pause and metric views


------
https://chatgpt.com/codex/tasks/task_b_6899f1770a5483239f5a79e94a8274db