### PR TITLE
feat: add core contracts and entity DAL

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -15,3 +15,8 @@
 - **prune_metrics**: DB helper removing older metric rows beyond a per-key limit.
 - **prune_old_days**: event bus helper deleting day directories older than ``keep_days``.
 - **prune_journal**: wrapper rotating journal file when size exceeds threshold.
+- **goal**: top-level objective stored in `state/e3.sqlite` with `title` and `drive`.
+- **plan**: strategy linked to a goal describing how to pursue it.
+- **step**: single command within a plan, executed sequentially.
+- **run**: record of executing a step including start/end times and return code.
+- **corr_id**: correlation identifier connecting events across a workflow.

--- a/bin/eidctl
+++ b/bin/eidctl
@@ -9,7 +9,7 @@ Usage examples:
 """
 
 from __future__ import annotations
-import argparse, json
+import argparse, json, dataclasses as dc
 
 # add repo root to sys.path so local 'core' can be imported without PYTHONPATH
 import sys
@@ -26,6 +26,9 @@ from core.state import (  # type: ignore
     rotate_journal,
     load_snapshot,
     diff_snapshots,
+    add_goal,
+    list_goals,
+    list_steps_for_goal,
 )
 
 def main(argv: list[str] | None = None) -> int:
@@ -72,6 +75,21 @@ def main(argv: list[str] | None = None) -> int:
         p_journal.add_argument(
             "--force", action="store_true", help="rotate even if under threshold"
         )
+
+        p_goals = sub.add_parser("goals", help="manage goals")
+        gsub = p_goals.add_subparsers(dest="goals_cmd", required=True)
+        gadd = gsub.add_parser("add", help="add goal")
+        gadd.add_argument("--title", required=True)
+        gadd.add_argument("--drive", required=True)
+        gadd.add_argument("--dir", default="state", help="state directory")
+        gls = gsub.add_parser("ls", help="list goals")
+        gls.add_argument("--dir", default="state", help="state directory")
+
+        p_steps = sub.add_parser("steps", help="inspect steps")
+        ssub = p_steps.add_subparsers(dest="steps_cmd", required=True)
+        sls = ssub.add_parser("ls", help="list steps for a goal")
+        sls.add_argument("--goal", required=True)
+        sls.add_argument("--dir", default="state", help="state directory")
 
         args = ap.parse_args(argv)
 
@@ -131,6 +149,23 @@ def main(argv: list[str] | None = None) -> int:
             evt = append_journal(args.dir, args.add, etype=args.etype or "note", tags=tags)
             print(f"[journal] appended: {evt['type']} @ {evt['ts']}")
             return 0
+
+        if args.cmd == "goals":
+            if args.goals_cmd == "add":
+                g = add_goal(args.dir, args.title, args.drive)
+                append_journal(args.dir, f"{g.title}", etype="goal.created", extra={"id": g.id})
+                print(g.id)
+                return 0
+            if args.goals_cmd == "ls":
+                gs = [dc.asdict(g) for g in list_goals(args.dir)]
+                print(json.dumps(gs, indent=2))
+                return 0
+
+        if args.cmd == "steps":
+            if args.steps_cmd == "ls":
+                steps = [dc.asdict(s) for s in list_steps_for_goal(args.dir, args.goal)]
+                print(json.dumps(steps, indent=2))
+                return 0
 
         return 2
     except KeyboardInterrupt:

--- a/core/contracts.py
+++ b/core/contracts.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Literal, Optional, Dict, Any
+
+Id = str  # ULIDs later
+
+
+@dataclass
+class Goal:
+    id: Id
+    title: str
+    drive: str
+    created_at: str
+
+
+@dataclass
+class Plan:
+    id: Id
+    goal_id: Id
+    kind: Literal["htn", "mcts", "adhoc"]
+    meta: Dict[str, Any]
+    created_at: str
+
+
+@dataclass
+class Step:
+    id: Id
+    plan_id: Id
+    idx: int
+    name: str
+    cmd: str
+    budget_s: float
+    status: Literal["todo", "ok", "fail"]
+    created_at: str
+
+
+@dataclass
+class Run:
+    id: Id
+    step_id: Id
+    started_at: str
+    ended_at: Optional[str]
+    rc: Optional[int]
+    bytes_out: int
+    notes: str

--- a/core/events.py
+++ b/core/events.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping
@@ -29,6 +30,8 @@ def append(
     data: Mapping[str, Any] | None = None,
     *,
     tags: List[str] | None = None,
+    corr_id: str | None = None,
+    parent_id: str | None = None,
     max_bytes: int = 5 * 1024 * 1024,
 ) -> Dict[str, Any]:
     """Append an event to the bus and return the event dict.
@@ -67,11 +70,15 @@ def append(
         except OSError:
             pass
 
+    corr_id = corr_id or uuid.uuid4().hex
+    parent_id = parent_id or corr_id
     evt = {
         "ts": _now_iso(),
         "type": str(etype),
         "data": dict(data or {}),
         "tags": list(tags or []),
+        "corr_id": corr_id,
+        "parent_id": parent_id,
     }
     with current.open("a", encoding="utf-8") as f:  # type: ignore[arg-type]
         f.write(json.dumps(evt, ensure_ascii=False) + "\n")

--- a/tests/test_core_state_entities.py
+++ b/tests/test_core_state_entities.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import sqlite3
+
+from core import state as S
+
+
+def test_crud_round_trip(tmp_path: Path):
+    base = tmp_path / "state"
+    g = S.add_goal(base, "T", "integrity")
+    goals = S.list_goals(base)
+    assert goals == [g]
+
+    p = S.add_plan(base, g.id, "htn", {"a": 1})
+    plans = S.list_plans(base, goal_id=g.id)
+    assert plans == [p]
+
+    s = S.add_step(base, p.id, 0, "s0", "echo hi", 1.0, "todo")
+    steps = S.list_steps(base, plan_id=p.id)
+    assert steps == [s]
+
+    steps_for_goal = S.list_steps_for_goal(base, g.id)
+    assert steps_for_goal == [s]
+
+    r = S.add_run(base, s.id, S._now_iso(), S._now_iso(), 0, 5, "")
+    runs = S.list_runs(base, step_id=s.id)
+    assert runs == [r]
+
+    conn = sqlite3.connect(base / "e3.sqlite")
+    try:
+        cnt = conn.execute(
+            "SELECT COUNT(*) FROM steps JOIN plans ON steps.plan_id=plans.id WHERE plans.goal_id=?",
+            (g.id,),
+        ).fetchone()[0]
+        assert cnt == 1
+    finally:
+        conn.close()

--- a/tests/test_events_corr.py
+++ b/tests/test_events_corr.py
@@ -1,0 +1,15 @@
+from core import events as E
+
+
+def test_corr_and_parent(tmp_path):
+    base = tmp_path / "state"
+    e1 = E.append(base, "root")
+    assert "corr_id" in e1 and e1["parent_id"] == e1["corr_id"]
+
+    e2 = E.append(base, "child", parent_id=e1["corr_id"])
+    assert e2["parent_id"] == e1["corr_id"]
+    assert e2["corr_id"] != e1["corr_id"]
+
+    events = E.iter_events(base)
+    assert events[-2]["corr_id"] == e1["corr_id"]
+    assert events[-1]["parent_id"] == e1["corr_id"]


### PR DESCRIPTION
## Summary
- define Goal, Plan, Step, Run dataclasses
- persist goals, plans, steps, and runs in SQLite with CRUD helpers
- log events with corr_id and parent_id, expand eidctl for goals and steps

## Testing
- `pytest -q`
- `bin/eidctl goals add --title "Hygiene: format & smoke" --drive integrity --dir /tmp/state`
- `bin/eidctl goals ls --dir /tmp/state`
- `bin/eidctl steps ls --goal 402445762aa04d47932539e939cb5bf1 --dir /tmp/state`


------
https://chatgpt.com/codex/tasks/task_b_6899fe33be6c8323bb78721bc4aa1c52