### PR TITLE
Add run artifacts, lint planning, and scheduler robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ datasets/sessions/
 .env
 .DS_Store
 # Local live config (seeded from cfg.sample)
-cfg/
+cfg/*
+!cfg/approvals.yaml

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -23,3 +23,4 @@
 - **approvals**: allow/deny gate applied before executing shell commands.
 - **sandbox**: resource-limited execution environment preventing escapes.
 - **HTN**: hierarchical task network planner using templates to expand goals into steps.
+- **run artifacts**: per-run directory under `state/runs/<run_id>/` with `stdout.txt`, `stderr.txt`, and `meta.json`.

--- a/actuators/approvals.py
+++ b/actuators/approvals.py
@@ -5,13 +5,36 @@ from typing import Sequence
 _DEFAULT_ALLOW = ["uv","pytest","ruff","black","git","bash","sh","make","python","pip"]
 _DEFAULT_DENY_TOKENS = ["curl","wget","ssh","nc","iptables","docker"]
 
-def allowed_cmd(cmd: Sequence[str], cwd: str, *,
-                allow_prefixes=None, deny_tokens=None) -> tuple[bool,str]:
+try:
+    import yaml
+except Exception:
+    yaml = None
+
+_CFG_PATH = Path("cfg/approvals.yaml")
+if yaml and _CFG_PATH.exists():
+    try:
+        _CFG = yaml.safe_load(_CFG_PATH.read_text(encoding="utf-8")) or {}
+    except Exception:
+        _CFG = {}
+else:
+    _CFG = {}
+
+
+def allowed_cmd(cmd: Sequence[str], cwd: str, *, template: str | None = None,
+                allow_prefixes=None, deny_tokens=None) -> tuple[bool, str]:
     """Return (ok, reason). Enforces prefix allowlist and deny token scan.
        CWD must be inside repo (no path escapes)."""
-    if not cmd: return False, "empty command"
-    allow = list(allow_prefixes or _DEFAULT_ALLOW)
-    deny = set(deny_tokens or _DEFAULT_DENY_TOKENS)
+    if not cmd:
+        return False, "empty command"
+    defaults = _CFG.get("defaults", {})
+    allow = list(allow_prefixes or defaults.get("allow_prefixes", _DEFAULT_ALLOW))
+    deny = set(deny_tokens or defaults.get("deny_tokens", _DEFAULT_DENY_TOKENS))
+    if template:
+        tpl = (_CFG.get("templates", {}) or {}).get(template, {})
+        if "allow_prefixes" in tpl:
+            allow = list(tpl["allow_prefixes"])
+        if "deny_tokens" in tpl:
+            deny = set(tpl["deny_tokens"])
     flat = " ".join(cmd)
     if any(t in flat for t in deny):
         return False, "denied token present"

--- a/actuators/shell_exec.py
+++ b/actuators/shell_exec.py
@@ -4,11 +4,12 @@ from typing import Sequence
 from core.state import add_run  # DB write
 from .approvals import allowed_cmd
 from .sandbox import run_sandboxed, SandboxError
+from core.artifacts import write_run_artifacts
 
 def run_step(base_dir: str, step_id: str, cmd: Sequence[str], *, cwd: str,
-             budget_s: float) -> dict:
+             budget_s: float, template: str | None = None) -> dict:
     """Gate + execute + persist run row. Returns run dict (for logs)."""
-    ok, reason = allowed_cmd(cmd, cwd)
+    ok, reason = allowed_cmd(cmd, cwd, template=template)
     if not ok:
         return {"status":"denied","reason":reason}
 
@@ -18,14 +19,29 @@ def run_step(base_dir: str, step_id: str, cmd: Sequence[str], *, cwd: str,
                                      cpu_quota_s=budget_s, mem_mb=1024)
         end = _now()
         r = add_run(base_dir, step_id, start, end, rc, len(out) + len(err), "")
+        try:
+            write_run_artifacts(base_dir, r.id, out, err,
+                                {"cmd": list(cmd), "cwd": str(cwd), "rc": int(rc), "status": "ok"})
+        except Exception:
+            pass
         return {"status":"ok","rc":rc,"run_id":r.id,"bytes":r.bytes_out}
     except SandboxError as e:
         end = _now()
         r = add_run(base_dir, step_id, start, end, None, 0, str(e))
+        try:
+            write_run_artifacts(base_dir, r.id, b"", b"",
+                                {"cmd": list(cmd), "cwd": str(cwd), "status":"timeout"})
+        except Exception:
+            pass
         return {"status":"timeout","run_id":r.id}
     except Exception as e:
         end = _now()
         r = add_run(base_dir, step_id, start, end, None, 0, f"error:{e}")
+        try:
+            write_run_artifacts(base_dir, r.id, b"", b"",
+                                {"cmd": list(cmd), "cwd": str(cwd), "status":"error", "error": str(e)})
+        except Exception:
+            pass
         return {"status":"error","run_id":r.id}
 
 def _now() -> str:

--- a/bin/eidctl
+++ b/bin/eidctl
@@ -29,7 +29,9 @@ from core.state import (  # type: ignore
     add_goal,
     list_goals,
     list_steps_for_goal,
+    list_runs,
 )
+from core.artifacts import run_dir
 
 def main(argv: list[str] | None = None) -> int:
     try:
@@ -90,6 +92,16 @@ def main(argv: list[str] | None = None) -> int:
         sls = ssub.add_parser("ls", help="list steps for a goal")
         sls.add_argument("--goal", required=True)
         sls.add_argument("--dir", default="state", help="state directory")
+
+        p_runs = sub.add_parser("runs", help="inspect runs")
+        rsub = p_runs.add_subparsers(dest="runs_cmd", required=True)
+        rls = rsub.add_parser("ls", help="list runs")
+        rls.add_argument("--dir", default="state", help="state directory")
+        rls.add_argument("--step", help="filter by step id")
+        rshow = rsub.add_parser("show", help="show run artifacts")
+        rshow.add_argument("--dir", default="state", help="state directory")
+        rshow.add_argument("--run", required=True)
+        rshow.add_argument("--head", type=int, default=200, help="max bytes to print per stream")
 
         args = ap.parse_args(argv)
 
@@ -165,6 +177,28 @@ def main(argv: list[str] | None = None) -> int:
             if args.steps_cmd == "ls":
                 steps = [dc.asdict(s) for s in list_steps_for_goal(args.dir, args.goal)]
                 print(json.dumps(steps, indent=2))
+                return 0
+
+        if args.cmd == "runs":
+            if args.runs_cmd == "ls":
+                runs = [dc.asdict(r) for r in list_runs(args.dir, step_id=args.step)]
+                for r in runs:
+                    print(f"{r['id']} {r['step_id']} rc={r.get('rc')} bytes={r.get('bytes_out')}")
+                return 0
+            if args.runs_cmd == "show":
+                d = run_dir(args.dir, args.run)
+                head = int(args.head)
+                for name in ("stdout", "stderr"):
+                    p = d / f"{name}.txt"
+                    data = p.read_bytes()[:head] if p.exists() else b""
+                    print(f"== {name} ==")
+                    if data:
+                        try:
+                            print(data.decode("utf-8", "replace"))
+                        except Exception:
+                            print(str(data))
+                    else:
+                        print("<empty>")
                 return 0
 
         return 2

--- a/bin/eidosd
+++ b/bin/eidosd
@@ -7,6 +7,8 @@ import os
 import random
 import sys
 from pathlib import Path as _P
+from datetime import datetime, timezone
+import sqlite3
 try:
     import yaml
 except Exception:
@@ -68,6 +70,26 @@ def run_once(state_dir: str, *, tick_secs: float, cpu: OM.CpuPercent) -> None:
     if not steps:
         SCH.plan({}, goal)
     else:
+        running = [s for s in steps if s.status == "running"]
+        if running:
+            s = running[0]
+            runs = S.list_runs(state_dir, s.id)
+            if runs:
+                last = runs[-1]
+                try:
+                    start = datetime.strptime(last.started_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+                except Exception:
+                    start = datetime.now(timezone.utc)
+                now = datetime.now(timezone.utc)
+                if (now - start).total_seconds() > 2 * s.budget_s:
+                    db = _P(state_dir) / "e3.sqlite"
+                    conn = sqlite3.connect(db)
+                    try:
+                        conn.execute("UPDATE steps SET status=? WHERE id=?", ("fail", s.id))
+                        conn.commit()
+                    finally:
+                        conn.close()
+            return
         todo = [s for s in steps if s.status == "todo"]
         if todo:
             s = todo[0]

--- a/cfg/approvals.yaml
+++ b/cfg/approvals.yaml
@@ -1,0 +1,6 @@
+defaults:
+  allow_prefixes: ["uv","pytest","ruff","black","git","bash","sh","make","python","pip"]
+  deny_tokens: ["curl","wget","ssh","nc","iptables","docker"]
+templates:
+  hygiene:
+    allow_prefixes: ["pytest","ruff","bash"]

--- a/core/artifacts.py
+++ b/core/artifacts.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Dict, Any, Literal
+
+__all__ = ["run_dir", "write_blob", "write_run_artifacts", "read_run_artifacts"]
+
+
+def run_dir(base: str | Path, run_id: str) -> Path:
+    """Return directory path for a run under ``base`` and ensure it exists."""
+    p = Path(base) / "runs" / str(run_id)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _safe_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("wb") as f:
+        f.write(data)
+        f.flush()
+    tmp.replace(path)  # atomic on POSIX
+
+
+def write_blob(base: str | Path, run_id: str, name: Literal["stdout", "stderr"], data: bytes) -> Path:
+    """Persist a single blob under the run directory and return its path."""
+    path = run_dir(base, run_id) / f"{name}.txt"
+    _safe_write(path, data or b"")
+    return path
+
+
+def write_run_artifacts(base: str | Path, run_id: str,
+                        stdout_bytes: bytes, stderr_bytes: bytes,
+                        meta: Dict[str, Any]) -> Path:
+    """
+    Persist run artifacts under ``state/runs/<run_id>/``:
+      - stdout.txt
+      - stderr.txt
+      - meta.json
+    Returns the directory path created.
+    """
+    base_dir = run_dir(base, run_id)
+    write_blob(base, run_id, "stdout", stdout_bytes)
+    write_blob(base, run_id, "stderr", stderr_bytes)
+    _safe_write(base_dir / "meta.json", json.dumps(meta or {}, ensure_ascii=False, indent=2).encode("utf-8"))
+    return base_dir
+
+
+def read_run_artifacts(base: str | Path, run_id: str) -> Dict[str, Any]:
+    """Load artifacts; missing files are treated as empty/defaults."""
+    base_dir = run_dir(base, run_id)
+    stdout_p = base_dir / "stdout.txt"
+    stderr_p = base_dir / "stderr.txt"
+    meta_p = base_dir / "meta.json"
+    out = stdout_p.read_bytes() if stdout_p.exists() else b""
+    err = stderr_p.read_bytes() if stderr_p.exists() else b""
+    if meta_p.exists():
+        try:
+            meta = json.loads(meta_p.read_text(encoding="utf-8"))
+        except Exception:
+            meta = {}
+    else:
+        meta = {}
+    return {"stdout": out, "stderr": err, "meta": meta}
+

--- a/core/contracts.py
+++ b/core/contracts.py
@@ -30,7 +30,7 @@ class Step:
     name: str
     cmd: str
     budget_s: float
-    status: Literal["todo", "ok", "fail"]
+    status: Literal["todo", "running", "ok", "fail"]
     created_at: str
 
 

--- a/planners/htn.py
+++ b/planners/htn.py
@@ -1,17 +1,38 @@
 from __future__ import annotations
 import yaml
+import shlex
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Mapping
 
-def materialize(template_name: str, goal_title: str) -> List[Dict[str, Any]]:
+
+def materialize(template_name: str, goal_title: str, vars: Mapping[str, str] | None = None) -> List[Dict[str, Any]]:
     p = Path(__file__).resolve().parent / "templates" / f"{template_name}.yaml"
     data = yaml.safe_load(p.read_text(encoding="utf-8"))
+    vars = vars or {}
+
+    def _subst(val: Any) -> Any:
+        if isinstance(val, str):
+            for k, v in vars.items():
+                val = val.replace(f"${{{k}}}", str(v))
+            return val
+        if isinstance(val, list):
+            out: List[str] = []
+            for item in val:
+                s = _subst(item)
+                if isinstance(s, str):
+                    out.extend(shlex.split(s))
+                else:
+                    out.append(s)
+            return out
+        return val
+
     steps = []
     for i, s in enumerate(data.get("steps", [])):
+        cmd = _subst(s.get("cmd", []))
         steps.append({
             "idx": i,
             "name": s["name"],
-            "cmd": s["cmd"],
+            "cmd": cmd,
             "budget_s": float(s.get("budget_s", 60)),
         })
     return steps

--- a/planners/registry.py
+++ b/planners/registry.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 from core.contracts import Goal
+
+
 def choose(goal: Goal) -> tuple[str, dict]:
-    if "hygiene" in goal.title.lower():
-        return "htn", {"template":"hygiene"}
-    return "htn", {"template":"hygiene"}  # default for now
+    title = goal.title.lower()
+    if "lint" in title:
+        return "htn", {"template": "lint"}
+    if "hygiene" in title:
+        return "htn", {"template": "hygiene", "vars": {"pytest_args": "-q"}}
+    return "htn", {"template": "hygiene", "vars": {"pytest_args": "-q"}}

--- a/planners/templates/hygiene.yaml
+++ b/planners/templates/hygiene.yaml
@@ -3,5 +3,5 @@ steps:
     cmd: ["ruff","--fix","."]
     budget_s: 30
   - name: test
-    cmd: ["pytest","-q"]
+    cmd: ["pytest","${pytest_args}"]
     budget_s: 300

--- a/planners/templates/lint.yaml
+++ b/planners/templates/lint.yaml
@@ -1,0 +1,10 @@
+steps:
+  - name: lint-fix
+    cmd: ["ruff","--fix","."]
+    budget_s: 60
+  - name: lint-check
+    cmd: ["ruff","."]
+    budget_s: 60
+  - name: test-lint
+    cmd: ["pytest","-q","-k","lint"]
+    budget_s: 120

--- a/tests/test_approvals_config.py
+++ b/tests/test_approvals_config.py
@@ -1,0 +1,26 @@
+import importlib
+import sys
+from pathlib import Path
+from actuators import approvals as A
+
+
+def test_template_config_allows_and_denies(tmp_path):
+    ok, _ = A.allowed_cmd(["bash", "-lc", "echo hi"], ".", template="hygiene")
+    assert ok
+    ok2, _ = A.allowed_cmd(["docker", "ps"], ".", template="hygiene")
+    assert not ok2
+
+
+def test_missing_config_fallback(tmp_path):
+    cfg = Path("cfg/approvals.yaml")
+    backup = tmp_path / "approvals.yaml"
+    cfg.rename(backup)
+    try:
+        sys.modules.pop("actuators.approvals", None)
+        A2 = importlib.import_module("actuators.approvals")
+        ok, _ = A2.allowed_cmd(["bash"], ".", template=None)
+        assert ok
+    finally:
+        backup.rename(cfg)
+        sys.modules.pop("actuators.approvals", None)
+        importlib.import_module("actuators.approvals")

--- a/tests/test_planners_lint.py
+++ b/tests/test_planners_lint.py
@@ -1,0 +1,13 @@
+from planners.registry import choose
+from planners.htn import materialize
+from core.contracts import Goal
+
+
+def test_choose_and_materialize_lint():
+    g = Goal("g2", "Lint: codebase", "integrity", "2025-01-01T00:00:00Z")
+    kind, meta = choose(g)
+    assert kind == "htn" and meta["template"] == "lint"
+    steps = materialize(meta["template"], g.title)
+    names = [s["name"] for s in steps]
+    assert names[:2] == ["lint-fix", "lint-check"]
+    assert steps[0]["cmd"][0] == "ruff"

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+from core import state as S
+from core import scheduler as SCH
+
+
+def test_retries(tmp_path: Path):
+    base = tmp_path / "state"
+    S.migrate(base)
+    SCH.STATE_DIR = str(base)
+    g = S.add_goal(base, "G", "d")
+    p = S.add_plan(base, g.id, "htn", {"template": "hygiene", "retries": {"0": 1}})
+    # step fails first then passes
+    done_path = base / "done"
+    cmd = ["bash", "-lc", f"if [ -f {done_path} ]; then exit 0; else touch {done_path}; exit 1; fi"]
+    S.add_step(base, p.id, 0, "flaky", json.dumps(cmd), 1.0, "todo")
+    step = S.list_steps(base)[0]
+
+    res1 = SCH.act({}, step)
+    SCH.verify({}, step, res1)
+    step_retry = S.list_steps(base)[0]
+    assert step_retry.status == "todo"
+
+    res2 = SCH.act({}, step_retry)
+    SCH.verify({}, step_retry, res2)
+    step_ok = S.list_steps(base)[0]
+    assert step_ok.status == "ok"
+
+    # step with retries=0 fails immediately
+    p2 = S.add_plan(base, g.id, "htn", {"template": "hygiene", "retries": {"0": 0}})
+    cmd_fail = ["bash", "-lc", "exit 1"]
+    S.add_step(base, p2.id, 0, "bad", json.dumps(cmd_fail), 1.0, "todo")
+    s2 = [s for s in S.list_steps(base) if s.plan_id == p2.id][0]
+    r = SCH.act({}, s2)
+    SCH.verify({}, s2, r)
+    s2_final = [s for s in S.list_steps(base) if s.id == s2.id][0]
+    assert s2_final.status == "fail"

--- a/tests/test_run_artifacts.py
+++ b/tests/test_run_artifacts.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import subprocess
+from core.artifacts import write_run_artifacts, read_run_artifacts
+from actuators.shell_exec import run_step
+
+
+def test_write_and_read_artifacts(tmp_path: Path):
+    base = tmp_path / "state"
+    run_id = "r1"
+    write_run_artifacts(base, run_id, b"hello\n", b"warn\n", {"k": 1})
+    data = read_run_artifacts(base, run_id)
+    assert data["stdout"].strip() == b"hello"
+    assert data["stderr"].strip() == b"warn"
+    assert data["meta"]["k"] == 1
+
+
+def test_runner_writes_artifacts_and_cli(tmp_path: Path):
+    base = tmp_path / "state"
+    base.mkdir(parents=True, exist_ok=True)
+    res = run_step(str(base), "step-1",
+                   ["bash", "-lc", "echo hi; echo oops 1>&2; exit 1"],
+                   cwd=".", budget_s=5.0)
+    assert res["status"] in ("ok", "timeout", "error", "denied") or res["status"] == "timeout"
+    run_id = res.get("run_id")
+    assert run_id, "runner should return a run_id"
+    d = base / "runs" / run_id
+    assert (d / "stdout.txt").exists()
+    assert (d / "stderr.txt").exists()
+
+    # CLI interaction
+    cmd_ls = ["python", "bin/eidctl", "runs", "ls", "--dir", str(base)]
+    out = subprocess.check_output(cmd_ls, text=True)
+    assert run_id in out
+
+    cmd_show = ["python", "bin/eidctl", "runs", "show", "--dir", str(base), "--run", run_id, "--head", "10"]
+    out_show = subprocess.check_output(cmd_show, text=True)
+    assert "hi" in out_show

--- a/tests/test_status_machine.py
+++ b/tests/test_status_machine.py
@@ -1,0 +1,43 @@
+import json
+import subprocess
+import sqlite3
+from pathlib import Path
+from core import state as S
+from core import scheduler as SCH
+
+
+def test_status_transitions(tmp_path: Path):
+    base = tmp_path / "state"
+    S.migrate(base)
+    SCH.STATE_DIR = str(base)
+    g = S.add_goal(base, "G", "d")
+    p = S.add_plan(base, g.id, "htn", {"template": "hygiene"})
+    S.add_step(base, p.id, 0, "echo", json.dumps(["bash", "-lc", "exit 0"]), 1.0, "todo")
+    step = S.list_steps(base)[0]
+
+    res = SCH.act({}, step)
+    step_running = S.list_steps(base)[0]
+    assert step_running.status == "running"
+
+    SCH.verify({}, step_running, res)
+    step_done = S.list_steps(base)[0]
+    assert step_done.status in ("ok", "fail")
+
+    # simulate stale running
+    db = base / "e3.sqlite"
+    runs = S.list_runs(base, step.id)
+    last_id = runs[-1].id
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("UPDATE steps SET status=? WHERE id=?", ("running", step.id))
+        conn.execute(
+            "UPDATE runs SET started_at=?, ended_at=? WHERE id=?",
+            ("2000-01-01T00:00:00Z", "2000-01-01T00:00:01Z", last_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    subprocess.run(["python", "bin/eidosd", "--once", "--dir", str(base)], check=True)
+    step_fail = S.list_steps(base)[0]
+    assert step_fail.status == "fail"

--- a/tests/test_template_vars.py
+++ b/tests/test_template_vars.py
@@ -1,0 +1,12 @@
+from planners.registry import choose
+from planners.htn import materialize
+from core.contracts import Goal
+
+
+def test_template_vars_substitution():
+    g = Goal("g3", "Hygiene: smoke", "integrity", "2025-01-01T00:00:00Z")
+    kind, meta = choose(g)
+    assert meta.get("vars")
+    steps = materialize(meta["template"], g.title, vars={"pytest_args": "-q -k smoke"})
+    test_step = [s for s in steps if s["name"] == "test"][0]
+    assert test_step["cmd"][:3] == ["pytest", "-q", "-k"]


### PR DESCRIPTION
## Summary
- Persist step run stdout/stderr/meta on disk and expose via `eidctl runs`
- Introduce `lint` planner template and support template variables with substitution
- Harden scheduler with running state, retries, approvals config, and timeout failover

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a0dfd10b88323a50b486eecbe4e2c